### PR TITLE
[OPS-4714] remove dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,7 @@
     "type": "git",
     "url": "https://github.com/jasondavies/d3-cloud.git"
   },
-  "scripts": {
-    "build": "mkdir -p build && browserify --standalone d3.layout.cloud index.js > build/d3.layout.cloud.js"
-  },
   "dependencies": {
     "d3-dispatch": "^1.0.3"
-  },
-  "devDependencies": {
-    "browserify": "^11.2.0"
   }
 }


### PR DESCRIPTION
This is a simple commit to remove browserify from the devDependencies, since we're not actively changing this repo and we don't really want to pull in all the third-party libs.